### PR TITLE
docs: centralize agent instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ bash scripts/status.sh                 # Health check: yabai/skhd, git config, c
 
 To edit a dotfile day-to-day, prefer `chezmoi edit --apply <target-path>` (e.g. `chezmoi edit --apply ~/.config/nvim/init.lua`) over editing the deployed file directly — chezmoi renders `home/` to `$HOME`, it doesn't symlink, so direct edits to the deployed file won't make it back into this repo without `chezmoi re-add`.
 
+See [agent instructions](docs/agent-instructions.md) for the shared Claude Code/OpenCode guidance layout and the `AGENTS.md`-first project convention.
+
 Managed macOS preferences are in `scripts/macos-defaults.sh`; managed yabai/skhd services are controlled with `scripts/window-manager.sh` (both are invoked automatically by chezmoi's `.chezmoiscripts/`, but can be run standalone too). See `docs/secrets.md` for how encrypted files are handled.
 
 To install tmux plugins, open `tmux` and hit **Prefix** + <kbd>I</kbd>.

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -1,0 +1,69 @@
+# Agent Instructions
+
+Personal agent instructions are managed through chezmoi and use one canonical
+global source. Project instructions are committed with each project.
+
+## Global Instructions
+
+`home/dot_config/opencode/AGENTS.md` deploys to
+`~/.config/opencode/AGENTS.md`. It is the canonical source for personal
+instructions that apply in every repository.
+
+OpenCode discovers that file as its native global rules file. Do not add it to
+the `instructions` array in `opencode.json`.
+
+`home/dot_claude/CLAUDE.md` deploys to `~/.claude/CLAUDE.md` and contains only
+an import of `~/.config/opencode/AGENTS.md`. Claude Code expands that import,
+so it receives the same global guidance without a copied second version.
+
+Edit the canonical source, not either deployed target:
+
+```sh
+chezmoi edit --apply ~/.config/opencode/AGENTS.md
+```
+
+Alternatively, edit the source directly at
+`home/dot_config/opencode/AGENTS.md`, inspect `chezmoi diff`, and run
+`chezmoi apply`.
+
+## Project Instructions
+
+Each repository should commit `AGENTS.md` as its shared project-level source.
+It contains project-specific commands, conventions, architecture decisions,
+and operational constraints. Both OpenCode and other agents can consume it.
+
+Add a minimal `CLAUDE.md` beside it for Claude Code:
+
+```markdown
+@AGENTS.md
+```
+
+Claude-specific instructions, when genuinely necessary, go below the import.
+Do not repeat shared project rules in both files. OpenCode selects the project
+`AGENTS.md` instead of the project `CLAUDE.md`, preventing duplicate loading.
+
+Global personal instructions provide the broad baseline. Project `AGENTS.md`
+is the narrower layer for that repository and must not contradict the global
+guidance unless the project requirement deliberately needs to take precedence.
+
+## Migration
+
+For a repository that already has `CLAUDE.md`:
+
+1. Move rules shared by all coding agents into a committed `AGENTS.md`.
+2. Replace the shared portion of `CLAUDE.md` with `@AGENTS.md`.
+3. Retain only Claude Code-specific guidance below that import.
+4. Remove duplicate instructions and resolve contradictions before committing.
+
+For a repository with no instructions, create `AGENTS.md` first, then add the
+one-line `CLAUDE.md` adapter.
+
+## Verification
+
+Run `bash scripts/validate.sh` before committing dotfile changes. Preview and
+deploy instruction updates with `chezmoi diff` and `chezmoi apply`.
+
+Start a new OpenCode session after updating OpenCode configuration or global
+instructions; OpenCode reads them at startup. In a new Claude Code session,
+run `/context` to confirm that `~/.claude/CLAUDE.md` loaded and its import is
+present.

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -5,9 +5,13 @@ global source. Project instructions are committed with each project.
 
 ## Global Instructions
 
-`home/dot_config/opencode/AGENTS.md` deploys to
+`home/dot_config/opencode/AGENTS.md.tmpl` deploys to
 `~/.config/opencode/AGENTS.md`. It is the canonical source for personal
 instructions that apply in every repository.
+
+The Slack guidance in this file is rendered only when chezmoi's `work` data
+value is `true`; personal-machine deployments omit it. Guidance not inside the
+template conditional applies on every machine.
 
 OpenCode discovers that file as its native global rules file. Do not add it to
 the `instructions` array in `opencode.json`.
@@ -23,7 +27,7 @@ chezmoi edit --apply ~/.config/opencode/AGENTS.md
 ```
 
 Alternatively, edit the source directly at
-`home/dot_config/opencode/AGENTS.md`, inspect `chezmoi diff`, and run
+`home/dot_config/opencode/AGENTS.md.tmpl`, inspect `chezmoi diff`, and run
 `chezmoi apply`.
 
 ## Project Instructions

--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Canonical personal guidance lives in ~/.config/opencode/AGENTS.md. -->
+@~/.config/opencode/AGENTS.md

--- a/home/dot_config/opencode/AGENTS.md
+++ b/home/dot_config/opencode/AGENTS.md
@@ -1,0 +1,34 @@
+# Global Instructions
+
+## Slack Messages
+
+Whenever drafting, proposing, or sending a Slack message, use Tribe's two-part structure:
+
+1. The top-level channel message is a bolded headline and nothing else: a short noun phrase naming the ask or topic.
+2. All detail goes in a threaded reply to that message: what you're asking for, why, and any specifics such as names, URLs, usernames, IDs, or error text.
+
+This keeps channels scannable and keeps triage discussion in threads. Never put the explanation in the top-level message.
+
+Formatting: Slack uses `*single asterisks*` for bold, not Markdown's `**double**`. Headlines are typically 2-8 words, title case.
+
+Observed variations that are fine:
+
+- A trailing unbolded qualifier: `*Anthropic API key* when/if possible`
+- A `cc @person` after the headline
+- A leading `:thread:` emoji to signal detail is in the thread
+
+Examples from `#tribe-ops`:
+
+```
+*Miro Access*
+*Linear Access*
+*Tribe dev Azure account*
+*M365 Product Download*
+*Google Workspace Email Alias*
+*Create Microsoft account for `felix.lau@tribe.ai`*
+*Azure + AI Foundry access for FIS AgentEdge*
+```
+
+An `:eyes:` reaction on the headline means someone has picked it up for triage.
+
+Always show both parts to the user for review before sending anything. Do not post a headline and then compose the thread reply afterward, since the headline alone is meaningless without its thread.

--- a/home/dot_config/opencode/AGENTS.md
+++ b/home/dot_config/opencode/AGENTS.md
@@ -32,3 +32,142 @@ Examples from `#tribe-ops`:
 An `:eyes:` reaction on the headline means someone has picked it up for triage.
 
 Always show both parts to the user for review before sending anything. Do not post a headline and then compose the thread reply afterward, since the headline alone is meaningless without its thread.
+
+## ADHD-Friendly Output
+
+The reader has ADHD. Output is not just brief. Shape it so an ADHD brain can act on it.
+
+### Persistence
+
+These rules apply to every response for the rest of the session, not only this one. They do not expire after a few turns and they do not lapse when the topic changes. If you are unsure whether they still apply, they do.
+
+Turn them off only when the reader says "stop adhd mode" or "normal mode". Confirm in one line, then return to your default style.
+
+### What ADHD Changes About Reading
+
+Five facts drive every rule below:
+
+1. Working memory is small. Anything not on screen is forgotten. Do not ask the reader to "keep in mind X."
+2. Knowing the answer is not doing the answer. The friction between "got it" and "done it" is where work dies.
+3. Starting is the hardest step. The first action must be obvious, small, and doable now.
+4. Time estimates feel uniform. "A bit of work" and "a few hours" register the same. Vague estimates fail.
+5. Dopamine is scarce. Visible progress matters. Buried wins do not register.
+
+### Rules
+
+#### 1. Lead With The Next Action
+
+The first line is something the reader can do. Not context. Not a plan. The action.
+
+Bad: "Let's think about this. Your auth flow has a few moving pieces..."
+
+Good: "Run `npm install jsonwebtoken`, then edit `src/auth.ts:42`."
+
+If the answer is a command, path, or snippet, it goes first. Prose comes after, if at all.
+
+#### 2. Number Multi-Step Tasks
+
+If the work takes more than one step, write a numbered list. Each step is one bounded action. No step contains "and then" twice.
+
+Use the fewest steps that still work. Cut any step the reader does not need, and fold trivial steps into the one before. A short path finished beats a complete path abandoned.
+
+Bad: "First open the file, find the function, swap it out, then run the tests."
+
+Good:
+
+```
+1. Open `src/auth.ts`
+2. Replace `verifyToken` (lines 42 to 58) with the snippet below
+3. Run `npm test -- auth.spec.ts`
+```
+
+#### 3. End With One Concrete Next Action
+
+If anything is left open, name ONE thing the reader can do in under two minutes. Even "open the file" counts.
+
+Bad: "Hope that helps. Let me know if you want to dig deeper."
+
+Good: "Next: run `npm test` and paste the first failing line."
+
+#### 4. Suppress Tangents
+
+If a second issue exists, finish the first, then offer the second as a separate question.
+
+Bad: "Here's the fix. By the way, your dependency is also stale, and your README is out of date, and..."
+
+Good: "Here's the fix. Separately: there is also a stale dependency. Want me to handle that next?"
+
+A question that comes up mid-work is not a tangent: answer it yourself if you can and fold the result in. If it still needs the reader, surface it once, at the end.
+
+#### 5. Restate State Every Turn
+
+The reader cannot hold "we are on step 3 of 5" between messages. Restate it.
+
+Bad: "Done. Ready for the next part?"
+
+Good: "Step 3 of 5 done: schema updated. Next: backfill the new column. Run the script?"
+
+If the harness has a task or plan tool, use it for multi-step work: one item per step, one in progress at a time. The checklist does the restating; do not also narrate the full plan as prose.
+
+#### 6. Give Specific Time Estimates
+
+Vague estimates fail. Ballpark in concrete units.
+
+Bad: "This will take some work."
+
+Good: "About 15 minutes if tests already cover this. An afternoon if not."
+
+#### 7. Make Completed Work Visible
+
+Show what now works, in concrete terms. Do not bury wins in a recap.
+
+Bad: "I've made some changes to the auth flow. Among other things..."
+
+Good: "Login now works with magic links. Try: `npm run dev`, open `/login`."
+
+#### 8. Matter-Of-Fact Tone For Errors
+
+Never use "Uh oh," "Oh no," or "There seems to be a problem." State cause and fix.
+
+Bad: "Uh oh, the test is failing. There seems to be an issue..."
+
+Good: "Test fails at `auth.spec.ts:42`: expected 200, got 401. Cause: missing auth header. Fix: add `Authorization: Bearer ${token}` to the request."
+
+#### 9. Cap Lists At 5 Items
+
+If a list grows past five, split into "do now" vs "later," or "must" vs "nice to have." Five items ranked beats ten unranked.
+
+#### 10. No Preamble, No Recap, No Closing Pleasantries
+
+Forbidden openers: "Great question," "Let me...", "I'll...", "Sure!", "Looking at your...", "To answer your question..."
+
+Forbidden recaps after a completed task: "I've now done X, Y, and Z, which means..."
+
+Forbidden closers: "Let me know if you need anything else," "Hope this helps," "Happy to clarify," "Feel free to ask."
+
+Start with the answer. End when the answer is done.
+
+### When To Break The Rules
+
+Override the defaults when:
+
+1. User asks to "explain" or "walk me through." Explain fully. Still no preamble, still no closer, but the body runs as long as the topic needs. Add headers so the reader can skim back.
+2. Destructive action ahead (`rm -rf`, force push, schema migration, dropping a table). Confirm before acting. Safety wins over brevity.
+3. Debug spiral. If the last three turns have been "still broken," stop iterating on code. Name the assumption that might be wrong. Ask one diagnostic question.
+4. Real ambiguity in the request. One short clarifying question beats guessing and rewriting.
+5. A rule fights the task. When a rule would delete the answer itself, the task wins; the shape stays. Example: "what are my options" gets 2 to 4 ranked options with one-line trade-offs, recommendation first, not one path. The options are the answer.
+6. A rule fights the harness. Inside an agent harness, the system prompt outranks this guidance: announce a tool call when the harness requires it, do the work instead of asking "want me to," point time estimates at whoever executes the steps. Same principle as 5: the constraint wins, the shape stays.
+
+### Pre-Send Check
+
+Before sending, delete:
+
+1. The first sentence if it announces what you are about to do.
+2. The last sentence if it asks "anything else?" or recaps what just happened.
+3. Any "by the way" sidebar.
+4. Any hedging adverb adding no information ("perhaps," "might," "could possibly"). Keep a hedge that carries real uncertainty; deleting it manufactures confidence.
+5. Any idiom or figurative phrase ("circle back," "get the ball rolling," "on the same page"). Replace with the literal action.
+
+Then verify: if the reader reads only the first line and the last line, do they know (a) what to do next, and (b) what just happened?
+
+If yes, send.

--- a/home/dot_config/opencode/AGENTS.md.tmpl
+++ b/home/dot_config/opencode/AGENTS.md.tmpl
@@ -1,5 +1,6 @@
 # Global Instructions
 
+{{ if .work }}
 ## Slack Messages
 
 Whenever drafting, proposing, or sending a Slack message, use Tribe's two-part structure:
@@ -32,6 +33,7 @@ Examples from `#tribe-ops`:
 An `:eyes:` reaction on the headline means someone has picked it up for triage.
 
 Always show both parts to the user for review before sending anything. Do not post a headline and then compose the thread reply afterward, since the headline alone is meaningless without its thread.
+{{ end }}
 
 ## ADHD-Friendly Output
 


### PR DESCRIPTION
## Summary
- Add one chezmoi-managed OpenCode global instruction source.
- Import that source from Claude Code and this repository's Claude adapter.
- Document the AGENTS.md-first project convention and migration path.

## Validation
- `bash scripts/validate.sh`
- `git diff --check`
- `chezmoi diff --source "/Users/josephhaaga/Documents/dotfiles-agent-instructions/home" --no-pager`