### PR TITLE
Fix personal chezmoi apply without age

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -1,4 +1,5 @@
 {{- if not .work }}
-.config/opencode/opencode.personal.json
-.config/zsh/.secrets
+# Without an age configuration, chezmoi treats encrypted sources as .age targets.
+.config/opencode/opencode.personal.json.age
+.config/zsh/.secrets.age
 {{- end }}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -43,7 +43,7 @@ if command -v chezmoi >/dev/null 2>&1; then
 
   personal_ignore="$(chezmoi execute-template --source "$DOTFILES/home" --override-data '{"work":false}' < "$DOTFILES/home/.chezmoiignore")"
   case "$personal_ignore" in
-    *".config/opencode/opencode.personal.json"*".config/zsh/.secrets"*) ;;
+    *".config/opencode/opencode.personal.json.age"*".config/zsh/.secrets.age"*) ;;
     *)
       echo "personal chezmoi configuration must ignore encrypted files" >&2
       exit 1


### PR DESCRIPTION
Summary:
- Ignore encrypted sources using their raw .age target paths when age is not configured.
- Validate those paths in the personal bootstrap check.

Testing:
- Isolated no-age chezmoi dry apply.
- bash scripts/validate.sh.