### PR TITLE
fix: preserve retained desktop behavior during v2 apply

### DIFF
--- a/v2/home/.chezmoiscripts/run_onchange_after_50-install-agent-tools.sh.tmpl
+++ b/v2/home/.chezmoiscripts/run_onchange_after_50-install-agent-tools.sh.tmpl
@@ -31,7 +31,9 @@ verify_installer "b644951c8d556414dacc4a7d70e1b6fd7e5674111ed3f533575aadb1b33424
   printf '%s\n' 'Plannotator installer checksum mismatch' >&2
   exit 1
 }
-bash "$installer" --version "$plannotator_version" --non-interactive \
+# The vendor installer has no Pi opt-out and updates Pi whenever it is on PATH.
+PATH="$HOME/.local/share/mise/shims:/usr/bin:/bin:/usr/sbin:/sbin" \
+  bash "$installer" --version "$plannotator_version" --non-interactive \
   --skip-skills --skip-codex --skip-gemini --skip-kiro --skip-opencode
 
 curl -fsSL https://terminal-browser.sh/install -o "$installer"

--- a/v2/home/dot_config/herdr/config.toml
+++ b/v2/home/dot_config/herdr/config.toml
@@ -20,3 +20,6 @@ auto_switch = false
 
 [keys]
 prefix = "ctrl+alt+g"
+
+[experimental]
+kitty_graphics = true


### PR DESCRIPTION
## Summary

- retain Herdr's Kitty graphics support in the v2 desktop configuration
- prevent Plannotator's installer from updating the intentionally removed Pi client
- keep the intentionally removed `herdr-pr` shortcut out of v2

## Pilot findings

- desktop v2 apply completed successfully
- `bash scripts/smoke-test.sh` passes
- OpenCode V2, tree-sitter, zsh, Neovim, Docker, and required commands verified

## Validation

- `bash scripts/validate.sh`
- rendered agent installer passes ShellCheck
- restricted installer PATH excludes Pi while retaining bash and mise-managed Node