### PR TITLE
chore: activate chezmoi v2 source

### DIFF
--- a/.chezmoiroot
+++ b/.chezmoiroot
@@ -1,1 +1,1 @@
-home
+v2/home

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Workflow
 
-- The new cross-platform chezmoi source is `v2/home/`. It supports the `desktop`, `server`, and `container` profiles described in `docs/profiles.md`.
-- `.chezmoiroot` intentionally remains `home` until the reviewed cutover. Editing v2 does not update `$HOME`; `setup` is the explicit v2 apply path.
-- Preview v2 with `chezmoi apply --dry-run --source "$PWD/v2/home" --override-data '{"profile":"desktop"}'`.
+- The active cross-platform chezmoi source is `v2/home/`. It supports the `desktop`, `server`, and `container` profiles described in `docs/profiles.md`.
+- `.chezmoiroot` points to `v2/home`; `setup` remains the explicit bootstrap path.
+- Preview v2 with `chezmoi apply --dry-run --source "$PWD" --override-data '{"profile":"desktop"}'`.
 - chezmoi copies and renders files; it does not symlink them. Do not edit deployed files while developing v2.
 - `v2/home/.chezmoidata/packages.yaml` is the package and portable-tool source of truth. Homebrew owns macOS packages, DNF owns Amazon Linux system packages, and mise owns portable tools and runtimes.
 - There is no work/personal split. Platform profiles control only capabilities such as GUI applications, services, and local-vault integration.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ The v2 source supports:
 - Amazon Linux 2023 development servers.
 - Non-root Linux development containers.
 
-## Safety During Review
+## Safe Preview
 
-v2 lives under `v2/home/` while `.chezmoiroot` continues to point at the legacy `home/` source. Checking out this branch does not change deployed dotfiles or uninstall applications.
+The active chezmoi source is `v2/home/`. The legacy `home/` source remains in the repository for rollback but is no longer applied.
 
 Preview the desktop profile without applying it:
 
 ```bash
 chezmoi apply --dry-run \
-  --source "$PWD/v2/home" \
+  --source "$PWD" \
   --override-data '{"profile":"desktop"}'
 ```
 
@@ -55,7 +55,7 @@ Alternatively, SSH first and run `herdr`. Detaching leaves remote panes and agen
 ```bash
 bash scripts/validate.sh
 bash scripts/smoke-test.sh
-chezmoi apply --source "$PWD/v2/home"
+chezmoi apply --source "$PWD"
 ```
 
 ## Documentation

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -45,10 +45,10 @@ DOTFILES_PROFILE=container ./setup
 
 ## Safe preview
 
-The current repository still points `.chezmoiroot` at the legacy `home/` tree. Preview v2 without changing `$HOME`:
+Preview the active source without changing `$HOME`:
 
 ```bash
-chezmoi apply --dry-run --source "$PWD/v2/home" --override-data '{"profile":"desktop"}'
+chezmoi apply --dry-run --source "$PWD" --override-data '{"profile":"desktop"}'
 ```
 
 `./setup` is the explicit action that applies v2.


### PR DESCRIPTION
## Summary

- point `.chezmoiroot` at the piloted `v2/home` source
- update root-level preview and apply commands
- retain legacy `home/` unchanged for rollback and later cleanup

## Pilot evidence

- real Apple Silicon desktop apply, smoke test, and exact verification pass
- clean Amazon Linux 2023 bootstrap, smoke test, and exact verification pass
- Docker and crond active; zsh and Docker group membership verified
- all 32 Neovim Tree-sitter parsers compile on Amazon Linux

## Validation

- `bash scripts/validate.sh`
- root-level desktop dry-run resolves with no changes
- root-level server template resolves to `v2/home`
- macOS, Linux, and container CI