### PR TITLE
feat: add Tailscale server access

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -27,6 +27,30 @@ bash scripts/smoke-test.sh
 herdr
 ```
 
+Join the VM to the tailnet interactively. The node identity remains local
+runtime state and is not managed by chezmoi:
+
+```bash
+sudo tailscale up --operator="$USER"
+```
+
+To expose the loopback-only OpenCode web server inside the tailnet, give its
+managed service a stable port and proxy it with Tailscale Serve:
+
+```bash
+opencode2 service set port 4096
+opencode2 service restart
+tailscale serve --bg localhost:4096
+```
+
+The OpenCode server retains its own generated password in addition to tailnet
+access control. Run `opencode2 pair` on the VM to display the credentials.
+
+OpenCode provider credentials are also local runtime state. From an interactive
+VM session, run `opencode2`, use `/connect`, and authenticate OpenAI with OAuth
+and Anthropic with its API key. Do not copy `~/.local/share/opencode/auth.json`
+into this repository.
+
 From another machine, attach with:
 
 ```bash

--- a/docs/secrets-v2.md
+++ b/docs/secrets-v2.md
@@ -6,6 +6,7 @@ Excluded runtime state includes:
 
 - GitHub and cloud CLI OAuth configuration.
 - OpenCode provider and MCP authentication.
+- Tailscale node identity and auth keys.
 - Docker registry credentials.
 - Slack cookies and keychain material.
 - Obsidian vault content beyond the selected app setting.

--- a/v2/home/.chezmoidata/packages.yaml
+++ b/v2/home/.chezmoidata/packages.yaml
@@ -96,6 +96,7 @@ packages:
     - mesa-libgbm
     - nss
     - pango
+    - tailscale
     - tar
     - tree
     - unzip

--- a/v2/home/.chezmoiscripts/run_onchange_after_45-configure-tailscale.sh.tmpl
+++ b/v2/home/.chezmoiscripts/run_onchange_after_45-configure-tailscale.sh.tmpl
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+{{ if eq .profile "server" -}}
+sudo systemctl enable --now tailscaled.service
+{{ else -}}
+printf '%s\n' 'Tailscale service is only configured on the server profile.'
+{{ end -}}

--- a/v2/home/.chezmoiscripts/run_onchange_before_05-configure-tailscale-repository.sh.tmpl
+++ b/v2/home/.chezmoiscripts/run_onchange_before_05-configure-tailscale-repository.sh.tmpl
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+{{ if eq .profile "server" -}}
+repo="$(mktemp)"
+trap 'rm -f "$repo"' EXIT
+
+cat >"$repo" <<'EOF'
+[tailscale-stable]
+name=Tailscale stable
+baseurl=https://pkgs.tailscale.com/stable/amazon-linux/2023/$basearch
+enabled=1
+type=rpm
+repo_gpgcheck=1
+gpgcheck=1
+gpgkey=https://pkgs.tailscale.com/stable/amazon-linux/2023/repo.gpg
+EOF
+
+sudo install -m 0644 "$repo" /etc/yum.repos.d/tailscale.repo
+{{ else -}}
+printf '%s\n' 'Tailscale RPM repository is only configured on the server profile.'
+{{ end -}}


### PR DESCRIPTION
## Summary

- add Tailscale's signed Amazon Linux 2023 RPM repository
- install Tailscale through the server package inventory
- enable and start `tailscaled`
- document tailnet access, Tailscale Serve, and machine-local OpenCode provider authentication

## Security

- no Tailscale auth keys, OpenAI OAuth tokens, or Anthropic API keys are managed by chezmoi
- OpenCode remains bound to loopback and Tailscale Serve provides tailnet-only HTTPS access
- OpenCode's generated Basic authentication remains enabled behind Tailscale

## Validation

- `bash scripts/validate.sh`
- Gitleaks reports no leaks
- rendered server scripts pass `bash -n`
- `git diff --check`