### PR TITLE
feat: add persistent OpenCode VM client

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -37,6 +37,21 @@ their client certificate instead of repeatedly prompting for the generated
 password. See [OpenCode web access](opencode-web.md) for the architecture,
 certificate roles, request flow, and secret-handling requirements.
 
+To connect the desktop TUI to the VM, create an `OpenCode VM` item in the
+1Password `Employee` vault and set its `password` field to the password shown
+by `/pair` in the VM TUI. The desktop profile keeps an SSH tunnel from local
+port `14096` to the VM's loopback-only OpenCode service and resolves that
+password only when launching:
+
+```bash
+opencode-vm
+opencode-vm --continue
+```
+
+The SSH private key and 1Password value remain local runtime state. The
+LaunchAgent uses `~/.ssh/id_ed25519` and requires the VM host key to already be
+present in `~/.ssh/known_hosts`.
+
 From another machine, attach with:
 
 ```bash

--- a/docs/opencode-web.md
+++ b/docs/opencode-web.md
@@ -89,6 +89,19 @@ The effective boundaries are:
 - Caddy to OpenCode: VM-local loopback HTTP, authenticated with OpenCode Basic auth.
 - Direct internet to OpenCode: impossible because OpenCode is not bound to a public interface.
 
+## Desktop TUI access
+
+The macOS desktop profile maintains an SSH local forward from
+`127.0.0.1:14096` to the VM's `127.0.0.1:49374`. A LaunchAgent starts the tunnel
+at login and restarts it after network interruptions. The `opencode-vm` alias
+connects a local TUI to the forwarded endpoint.
+
+OpenCode still authenticates this direct connection. The alias runs the client
+through 1Password CLI using the secret reference in
+`~/.config/opencode/opencode-vm.env`; the password is resolved only for the
+child process and is never rendered by chezmoi. Use `/pair` in the VM TUI to
+obtain the password when initially creating or updating the 1Password item.
+
 ## Secret handling
 
 Only non-secret configuration and the public client CA certificate belong in

--- a/v2/home/.chezmoiignore
+++ b/v2/home/.chezmoiignore
@@ -12,6 +12,7 @@
 {{- if ne .profile "desktop" }}
 # macOS-only configuration and applications.
 .config/ghostty
+.config/opencode/opencode-vm.env
 .skhdrc
 .config/skhd
 .config/yabai

--- a/v2/home/.chezmoiscripts/run_onchange_after_75-configure-opencode-tunnel.sh.tmpl
+++ b/v2/home/.chezmoiscripts/run_onchange_after_75-configure-opencode-tunnel.sh.tmpl
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# LaunchAgent: {{ include "private_Library/private_LaunchAgents/com.josephhaaga.opencode-tunnel.plist.tmpl" | sha256sum }}
+
+{{ if eq .profile "desktop" -}}
+label="com.josephhaaga.opencode-tunnel"
+domain="gui/$(id -u)"
+unit="{{ .chezmoi.homeDir }}/Library/LaunchAgents/$label.plist"
+
+launchctl bootout "$domain/$label" 2>/dev/null || true
+launchctl enable "$domain/$label"
+launchctl bootstrap "$domain" "$unit"
+{{ else -}}
+printf '%s\n' 'OpenCode SSH tunnel is only configured on the desktop profile.'
+{{ end -}}

--- a/v2/home/dot_config/opencode/opencode-vm.env
+++ b/v2/home/dot_config/opencode/opencode-vm.env
@@ -1,0 +1,1 @@
+OPENCODE_PASSWORD="op://Employee/OpenCode VM/password"

--- a/v2/home/dot_config/zsh/dot_zshrc
+++ b/v2/home/dot_config/zsh/dot_zshrc
@@ -37,6 +37,10 @@ if command -v opencode2 >/dev/null 2>&1; then
   alias opencode=opencode2
 fi
 
+if command -v op >/dev/null 2>&1 && command -v opencode2 >/dev/null 2>&1 && [[ -f "$HOME/.config/opencode/opencode-vm.env" ]]; then
+  alias opencode-vm='op run --env-file="$HOME/.config/opencode/opencode-vm.env" -- opencode2 --server http://127.0.0.1:14096'
+fi
+
 if [[ -o interactive ]] && command -v kubectl >/dev/null 2>&1; then
   source <(kubectl completion zsh)
   alias k=kubectl

--- a/v2/home/private_Library/private_LaunchAgents/com.josephhaaga.opencode-tunnel.plist.tmpl
+++ b/v2/home/private_Library/private_LaunchAgents/com.josephhaaga.opencode-tunnel.plist.tmpl
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.josephhaaga.opencode-tunnel</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/bin/ssh</string>
+		<string>-NT</string>
+		<string>-o</string>
+		<string>BatchMode=yes</string>
+		<string>-o</string>
+		<string>ExitOnForwardFailure=yes</string>
+		<string>-o</string>
+		<string>ServerAliveInterval=30</string>
+		<string>-o</string>
+		<string>ServerAliveCountMax=3</string>
+		<string>-o</string>
+		<string>IdentitiesOnly=yes</string>
+		<string>-i</string>
+		<string>{{ .chezmoi.homeDir }}/.ssh/id_ed25519</string>
+		<string>-L</string>
+		<string>14096:127.0.0.1:49374</string>
+		<string>ec2-user@josephhaaga.sh.tribe.ai</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<dict>
+		<key>NetworkState</key>
+		<true/>
+	</dict>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ThrottleInterval</key>
+	<integer>10</integer>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- keep an authenticated SSH tunnel to the VM OpenCode service running with a macOS LaunchAgent
- add `opencode-vm` for launching a local TUI through the tunnel
- resolve `OPENCODE_PASSWORD` from 1Password only for the child process
- document the one-time `/pair` and 1Password setup

## Security

The repository stores only `op://Employee/OpenCode VM/password`. The OpenCode password and SSH private key remain local runtime state.

## Validation

- `bash scripts/validate.sh`
- desktop `chezmoi apply --dry-run --force`
- rendered LaunchAgent `plutil -lint`
- `zsh -n v2/home/dot_config/zsh/dot_zshrc`
- `git diff --check`
